### PR TITLE
Clean up vim and zsh config

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -25,7 +25,6 @@ Bundle 'ambv/black'
 Bundle 'tpope/vim-git'
 
 " syntax files
-Bundle 'fisadev/vim-isort'
 Bundle 'tpope/vim-markdown'
 Bundle 'tell-k/vim-autopep8'
 Bundle 'posva/vim-vue'
@@ -175,9 +174,6 @@ let g:autopep8_indent_size=4
 " black doesn't support AutoFormatBuffer b/c it doesn't handle line ranges, so you need this
 " instead.
 " autocmd BufWritePre *.py execute ':Black'
-
-" Run iSort automatically on every save
-autocmd BufWritePost *.py Isort
 
 """ Black
 let g:black_linelength=100

--- a/.zshrc
+++ b/.zshrc
@@ -1,66 +1,25 @@
-# If you come from bash you might have to change your $PATH.
-# export PATH=$HOME/bin:/usr/local/bin:$PATH
+# Keep CLI tools reachable even if plugin loading fails.
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:$PATH"
+case ":$PATH:" in
+  *":/Applications/Codex.app/Contents/Resources:"*) ;;
+  *) export PATH="$PATH:/Applications/Codex.app/Contents/Resources" ;;
+esac
 
-# Path to your oh-my-zsh installation.
-export ZSH=/Users/anahm/.oh-my-zsh
+# Google Cloud SDK
+if [ -f "$(brew --prefix)/Caskroom/gcloud-cli/latest/google-cloud-sdk/path.zsh.inc" ]; then
+  source "$(brew --prefix)/Caskroom/gcloud-cli/latest/google-cloud-sdk/path.zsh.inc"
+  source "$(brew --prefix)/Caskroom/gcloud-cli/latest/google-cloud-sdk/completion.zsh.inc"
+fi
 
-# Set name of the theme to load. Optionally, if you set this to "random"
-# it'll load a random theme each time that oh-my-zsh is loaded.
-# See https://github.com/robbyrussell/oh-my-zsh/wiki/Themes
-ZSH_THEME="robbyrussell"
-
-# Uncomment the following line to use case-sensitive completion.
-# CASE_SENSITIVE="true"
-
-# Uncomment the following line to use hyphen-insensitive completion. Case
-# sensitive completion must be off. _ and - will be interchangeable.
-# HYPHEN_INSENSITIVE="true"
-
-# Uncomment the following line to disable bi-weekly auto-update checks.
-# DISABLE_AUTO_UPDATE="true"
-
-# Uncomment the following line to change how often to auto-update (in days).
-# export UPDATE_ZSH_DAYS=13
-
-# Uncomment the following line to disable colors in ls.
-# DISABLE_LS_COLORS="true"
-
-# Uncomment the following line to disable auto-setting terminal title.
-# DISABLE_AUTO_TITLE="true"
-
-# Uncomment the following line to enable command auto-correction.
-# ENABLE_CORRECTION="true"
-
-# Uncomment the following line to display red dots whilst waiting for completion.
-# COMPLETION_WAITING_DOTS="true"
-
-# Uncomment the following line if you want to disable marking untracked files
-# under VCS as dirty. This makes repository status check for large repositories
-# much, much faster.
-# DISABLE_UNTRACKED_FILES_DIRTY="true"
-
-# Uncomment the following line if you want to change the command execution time
-# stamp shown in the history command output.
-# The optional three formats: "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
-HIST_STAMPS="yyyy-mm-dd"
-
-# Would you like to use another custom folder than $ZSH/custom?
-# ZSH_CUSTOM=/path/to/new-custom-folder
-
-# Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
-# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
-# Example format: plugins=(rails git textmate ruby lighthouse)
-# Add wisely, as too many plugins slow down shell startup.
-plugins=(git history)
-
-source $ZSH/oh-my-zsh.sh
-
-# User configuration
-
-# export MANPATH="/usr/local/man:$MANPATH"
-
-# You may need to manually set your language environment
-# export LANG=en_US.UTF-8
+# Antidote + plugin bundle list
+export ANTIDOTE_HOME="$HOME/.antidote"
+export ANTIDOTE_PLUGINS_FILE="$HOME/Documents/Code/a-dotfiles/.zsh_plugins.txt"
+autoload -Uz compinit
+compinit
+if [[ -f "$ANTIDOTE_HOME/antidote.zsh" && -f "$ANTIDOTE_PLUGINS_FILE" ]]; then
+  source "$ANTIDOTE_HOME/antidote.zsh"
+  source <(antidote load "$ANTIDOTE_PLUGINS_FILE")
+fi
 
 # Preferred editor for local and remote sessions
 if [[ -n $SSH_CONNECTION ]]; then
@@ -69,29 +28,13 @@ else
   export EDITOR='mvim'
 fi
 
-# Compilation flags
-# export ARCHFLAGS="-arch x86_64"
-
-# ssh
-# export SSH_KEY_PATH="~/.ssh/rsa_id"
-
-# Set personal aliases, overriding those provided by oh-my-zsh libs,
-# plugins, and themes. Aliases can be placed here, though oh-my-zsh
-# users are encouraged to define aliases within the ZSH_CUSTOM folder.
-# For a full list of active aliases, run `alias`.
-#
-# Example aliases
-# alias zshconfig="mate ~/.zshrc"
-# alias ohmyzsh="mate ~/.oh-my-zsh"
-
-# Adding bash config
+# Load bash config for legacy aliases/functions
 if [ -f $HOME/.bashrc ]; then
     . $HOME/.bashrc
 fi
 
 export PYENV_ROOT=~/.pyenv
 export PATH=$PYENV_ROOT/shims:$PATH
-
 
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
@@ -102,3 +45,14 @@ if command -v pyenv 1>/dev/null 2>&1; then
     eval "$(pyenv init -)"
 fi
 export PYTHON_CONFIGURE_OPTS="--enable-framework"
+
+# Final fallback in case PATH was clobbered by later scripts.
+if ! command -v claude >/dev/null 2>&1 && [ -x /opt/homebrew/bin/claude ]; then
+  alias claude='/opt/homebrew/bin/claude'
+fi
+if ! command -v codex >/dev/null 2>&1 && [ -x /opt/homebrew/bin/codex ]; then
+  alias codex='/opt/homebrew/bin/codex'
+fi
+
+# Other keyboard shortcuts
+alias claude-mcp="open ~/Library/Application\ Support/Claude/claude_desktop_config.json"


### PR DESCRIPTION
## Summary
- remove the remaining iSort autocmd from `.vimrc`
- simplify `.zshrc` from oh-my-zsh defaults to the current antidote-based setup
- keep PATH/editor/python/nvm initialization and add codex/claude fallback aliases

## Notes
- intentionally excludes untracked `.vim/bundle/*` plugin directories